### PR TITLE
Configurable base uri

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM semtech/mu-ruby-template:2.11.0
 LABEL maintainer="erika.pauwels@gmail.com"
 
 ENV MU_APPLICATION_FILE_STORAGE_PATH ''
+ENV FILE_RESOURCE_BASE 'http://mu.semte.ch/services/file-service/files/'
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ If you want to model the files of the file service in the domain of your [mu-cl-
 ```lisp
 (define-resource file ()
   :class (s-prefix "nfo:FileDataObject")
-  :properties `((:filename :string ,(s-prefix "nfo:fileName"))
+  :properties `((:name :string ,(s-prefix "nfo:fileName"))
                 (:format :string ,(s-prefix "dct:format"))
                 (:size :number ,(s-prefix "nfo:fileSize"))
                 (:extension :string ,(s-prefix "dbpedia:fileExtension"))

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ file:
     - ./data/my-project/uploads:/share/my-project/uploads
 ```
 
+### Resource base-URI
+
+The URI for a new upload-file resource is assembled by concatenating a resource-base with a uuid. The default base-URI is `http://mu.semte.ch/services/file-service/files/`. The base-URI is configurable through the environment variable `FILE_RESOURCE_BASE` and should contain the trailing `/`. Also see chapter "Data model > Resources" below for more information regarding upload file resources.
+
+
 ## REST API
 #### POST /files
 Upload a file. Accepts a `multipart/form-data` with a `file` parameter containing the uploaded file.

--- a/web.rb
+++ b/web.rb
@@ -14,6 +14,7 @@ end
 configure do
   set :relative_storage_path, (ENV['MU_APPLICATION_FILE_STORAGE_PATH'] || '').chomp('/')
   set :storage_path, "/share/#{(ENV['MU_APPLICATION_FILE_STORAGE_PATH'] || '')}".chomp('/')
+  set :file_resource_base, (ENV['FILE_RESOURCE_BASE'] || '')
 end
 
 file_magic = FileMagic.new(FileMagic::MAGIC_MIME)
@@ -26,8 +27,6 @@ DC = RDF::Vocab::DC
 NFO = RDF::Vocabulary.new('http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#')
 NIE = RDF::Vocabulary.new('http://www.semanticdesktop.org/ontologies/2007/01/19/nie#')
 DBPEDIA = RDF::Vocabulary.new('http://dbpedia.org/ontology/')
-
-FILE_SERVICE_RESOURCE_BASE = 'http://mu.semte.ch/services/file-service'
 
 ###
 # POST /files
@@ -49,7 +48,7 @@ post '/files/?' do
 
   upload_resource_uuid = generate_uuid()
   upload_resource_name = params['file'][:filename]
-  upload_resource_uri = "#{FILE_SERVICE_RESOURCE_BASE}/files/#{upload_resource_uuid}"
+  upload_resource_uri = "#{settings.file_resource_base}#{upload_resource_uuid}"
 
   file_format = file_magic.file(tempfile.path)
   file_extension = upload_resource_name.split('.').last


### PR DESCRIPTION
Up until now, newly  created upload-file resources always get assigned a URI that starts with `http://mu.semte.ch/services/file-service`. In some settings (with data-publication according to certain standards in mind), one might want something else as base-uri. This PR makes the base-uri for upload-file resources configurable. The default stays the same in order to preserve reverse compatibility. The physical `share://`-URI's also function exactly the same as before.