### PR TITLE
Split delete query in two parts.

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -192,28 +192,35 @@ delete '/files/:id' do
 
   return status 404 if result.empty?
 
-  query =  " DELETE WHERE {"
-  query += "   GRAPH <#{graph}> {"
-  query += "     <#{result.first[:uri]}> a <#{NFO.FileDataObject}> ;"
-  query += "       <#{NFO.fileName}> ?upload_name ;"
-  query += "       <#{MU_CORE.uuid}> ?upload_id ;"
-  query += "       <#{DC.format}> ?upload_format ;"
-  query += "       <#{DBPEDIA.fileExtension}> ?upload_extension ;"
-  query += "       <#{NFO.fileSize}> ?upload_size ;"
-  query += "       <#{DC.created}> ?upload_created ;"
-  query += "       <#{DC.modified}> ?upload_modified ."
-  query += "     <#{result.first[:fileUrl]}> a <#{NFO.FileDataObject}> ;"
-  query += "       <#{NIE.dataSource}> <#{result.first[:uri]}> ;"
-  query += "       <#{NFO.fileName}> ?fileName ;"
-  query += "       <#{MU_CORE.uuid}> ?id ;"
-  query += "       <#{DC.format}> ?format ;"
-  query += "       <#{DBPEDIA.fileExtension}> ?extension ;"
-  query += "       <#{NFO.fileSize}> ?size ;"
-  query += "       <#{DC.created}> ?created ;"
-  query += "       <#{DC.modified}> ?modified ."
-  query += "   }"
-  query += " }"
-  update(query)
+  delete_query = "
+    DELETE WHERE {
+      GRAPH <#{graph}> {
+        <#{result.first[:uri]}> a <#{NFO.FileDataObject}> ;
+          <#{NFO.fileName}> ?upload_name ;
+          <#{MU_CORE.uuid}> ?upload_id ;
+          <#{DC.format}> ?upload_format ;
+          <#{DBPEDIA.fileExtension}> ?upload_extension ;
+          <#{NFO.fileSize}> ?upload_size ;
+          <#{DC.created}> ?upload_created ;
+          <#{DC.modified}> ?upload_modified .
+      }
+    }
+   ;
+   DELETE WHERE {
+    GRAPH <#{graph}> {
+      <#{result.first[:fileUrl]}> a <#{NFO.FileDataObject}> ;
+        <#{NIE.dataSource}> ?v_file ;
+        <#{NFO.fileName}> ?fileName ;
+        <#{MU_CORE.uuid}> ?id ;
+        <#{DC.format}> ?format ;
+        <#{DBPEDIA.fileExtension}> ?extension ;
+        <#{NFO.fileSize}> ?size ;
+        <#{DC.created}> ?created ;
+        <#{DC.modified}> ?modified .
+    }
+  }
+  "
+  update(delete_query)
 
   url = result.first[:fileUrl].value
   path = shared_uri_to_path(url)

--- a/web.rb
+++ b/web.rb
@@ -192,6 +192,12 @@ delete '/files/:id' do
 
   return status 404 if result.empty?
 
+  # NOTE: this is split in two queries because it's lighter on the
+  # triplestore.  Ideally mu-auth can split these queries in smarter and
+  # lighter way to alleviate the triplestore when the data lives in more
+  # than one graph.
+
+
   delete_query = "
     DELETE WHERE {
       GRAPH <#{graph}> {
@@ -209,7 +215,7 @@ delete '/files/:id' do
    DELETE WHERE {
     GRAPH <#{graph}> {
       <#{result.first[:fileUrl]}> a <#{NFO.FileDataObject}> ;
-        <#{NIE.dataSource}> ?v_file ;
+        <#{NIE.dataSource}> #{result.first[:uri]} ;
         <#{NFO.fileName}> ?fileName ;
         <#{MU_CORE.uuid}> ?id ;
         <#{DC.format}> ?format ;


### PR DESCRIPTION
Given a file residing in multiple graphs (> 2), the original query
didn't perform well when it gets transformed by mu-auth and sent to
virtuoso.

The problem is related to virtuoso, which estimates the
cost of executing the transformed query as extraordinarily high and
therefore, blocking the execution.

I am aware the need for a re-write is implementation-specific and the
solution might not work if the amount of graphs keeps on growing.

However, virtuoso isn't going to go away soon, it is working better
now and the result - I assume - of the re-write is the logical equivalent of the
original query.

There is a risk for unexpected consequences on how
deltas are propagated through mu-auth (one block of deletes/inserts, vs
multiple blocks?) and potentially affect consuming services.
I didn't test for that, but in my defence, I would state:
  - mu-auth potentially might eventually fold the resulting changesets
of such calls
  - Services should be robust and not assume transaction-like blocks
in the handling of incoming deltas. (i.e. be in line with the general
philosophy of reactive microservices in a semantic.works stack)

This rewrite will be tested in some of the deployed stacks, so we'll
have an idea of its validity soon.