### PR TITLE
Configurable content disposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Download the content of the file with the given id.
 
 ##### Query paramaters
 * `name` (optional): name for the downloaded file (e.g. `/files/1/download?name=report.pdf`)
+* `content-disposition` (optional): specify with which [Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header-value you want the service to respond. Defaults to `attachment`.
 
 ##### Response
 

--- a/web.rb
+++ b/web.rb
@@ -169,8 +169,19 @@ get '/files/:id/download' do
 
   filename = params['name']
   filename ||= File.basename(path)
+  
+  if params['content-disposition']
+    if (params['content-disposition'].casecmp 'inline') == 0
+      disposition = 'inline'
+    else
+      disposition = 'attachment'
+    end
+  else
+    disposition = 'attachment'
+  end
+
   if File.file?(path)
-    send_file path, disposition: 'attachment', filename: filename
+    send_file path, disposition: disposition, filename: filename
   else
     error("Could not find file in path. Check if the physical file is available on the server and if this service has the right mountpoint.", 500)
   end

--- a/web.rb
+++ b/web.rb
@@ -169,13 +169,9 @@ get '/files/:id/download' do
 
   filename = params['name']
   filename ||= File.basename(path)
-  
-  if params['content-disposition']
-    if (params['content-disposition'].casecmp 'inline') == 0
-      disposition = 'inline'
-    else
-      disposition = 'attachment'
-    end
+
+  if params['content-disposition'] and params['content-disposition'].casecmp? 'inline'
+    disposition = 'inline'
   else
     disposition = 'attachment'
   end


### PR DESCRIPTION
See https://chat.semte.ch/channel/mu-semtech?msg=f9wz93HZoZAXe6mn4 . 
Gives the client control over the `Content-Disposition`-header. Defaults to `attachment` in order to maintain file-service reverse compatibility. Erroneous values also result in `attachment`, analogous to the HTML spec.