### PR TITLE
README: Correct resource snippet to dct:created

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you want to model the files of the file service in the domain of your [mu-cl-
                 (:format :string ,(s-prefix "dct:format"))
                 (:size :number ,(s-prefix "nfo:fileSize"))
                 (:extension :string ,(s-prefix "dbpedia:fileExtension"))
-                (:created :datetime ,(s-prefix "nfo:fileCreated")))
+                (:created :datetime ,(s-prefix "dct:created")))
   :has-one `((file :via ,(s-prefix "nie:dataSource")
                    :inverse t
                    :as "download"))


### PR DESCRIPTION
This aligns the sample mu-cl-resources configuration snippet with the API offered by file-service.
