### PR TITLE
Add missing Mu:: prefix for log statements

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -10,7 +10,7 @@ def boolean_env env_var
 end
 
 if ENV['MU_APPLICATION_FILE_STORAGE_PATH'] and ENV['MU_APPLICATION_FILE_STORAGE_PATH'].start_with?('/')
-  log.fatal "MU_APPLICATION_FILE_STORAGE_PATH (#{ENV['MU_APPLICATION_FILE_STORAGE_PATH']}) must be relative"
+  Mu::log.fatal "MU_APPLICATION_FILE_STORAGE_PATH (#{ENV['MU_APPLICATION_FILE_STORAGE_PATH']}) must be relative"
   exit
 else
   FileUtils.mkdir_p "/share/#{ENV['MU_APPLICATION_FILE_STORAGE_PATH']}"
@@ -133,11 +133,11 @@ post '/files/?' do
       }.to_json
     end
   rescue UnauthorizedError => e
-    log.warn "#{e} Cleaning up."
+    Mu::log.warn "#{e} Cleaning up."
     File.delete physical_file_path if File.exist? physical_file_path
     status 403
   rescue SPARQL::Client::MalformedQuery, SPARQL::Client::ClientError, SPARQL::Client::ServerError => e
-    log.warn "Something went wrong while upload file. Cleaning up. #{e}"
+    Mu::log.warn "Something went wrong while upload file. Cleaning up. #{e}"
     File.delete physical_file_path if File.exist? physical_file_path
     status 500
   end


### PR DESCRIPTION
Errors in file-service are also internally failing on these log statements.

```
"sinatra.error"=>#<NameError: undefined local variable or method 'log' for #<Sinatra::Application:0x00007fb2a34b6e20 ...>>}>, @response=#<Sinatra::Response:0x00007fb2a3496698 @status=500, @headers={}, @writer=#<Method: Sinatra::Response(Rack::Response::Helpers)#append(chunk) 
/usr/local/bundle/gems/rack-2.2.8/lib/rack/response.rb:287>, 
@block=nil, @body=[], @buffered=true, @length=0>>:
/usr/src/app/ext/web.rb:140:in `rescue in block in <top (required)>'

```

Based on this commit of Niels I guess it just needs `Mu::`
https://github.com/mu-semtech/mu-ruby-template/commit/3179d8cb4add554f2c32094beb6cb08866d4b052