### PR TITLE
fix: graph variable mu::graph when fetching file info

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -39,7 +39,7 @@ DBPEDIA = RDF::Vocabulary.new('http://dbpedia.org/ontology/')
 # Supporting functions
 ###
 def get_file_info file_uuid
-  query = " SELECT ?uri ?name ?format ?size ?extension FROM <#{graph}> WHERE {"
+  query = " SELECT ?uri ?name ?format ?size ?extension FROM <#{Mu::graph}> WHERE {"
   query += "   ?uri <#{MU_CORE.uuid}> #{Mu::sparql_escape_string(file_uuid)} ;"
   query += "        <#{NFO.fileName}> ?name ;"
   query += "        <#{DC.format}> ?format ;"


### PR DESCRIPTION
When uploading getting this error.


```
file-1  | 2026-07-02 13:57:43 - NameError - undefined local variable or method 'graph' for an instance of Sinatra::Application:
file-1  | 	
file-1  | 	  query = " SELECT ?uri ?name ?format ?size ?extension FROM <#{graph}> WHERE {"
file-1  | 	                                                               ^^^^^
file-1  | 	/usr/src/app/ext/web.rb:42:in 'Object#get_file_info'
file-1  | 	/usr/src/app/ext/web.rb:114:in 'block in <top (required)>'
file-1  | 	/usr/local/bundle/gems/sinatra-4.1.1/lib/sinatra/base.rb:1807:in 'Method#call'
file-1  | 	/usr/local/bundle/gems/sinatra-4.1.1/lib/sinatra/base.rb:1807:in 'block in Sinatra::Base.compile!'
file-1  | 	/usr/local/bundle/gems/sinatra-4.1.1/lib/sinatra/base.rb:1074:in 'block (3 levels) in Sinatra::Base#route!'
```